### PR TITLE
From coldfix pr1

### DIFF
--- a/bin/pyeval
+++ b/bin/pyeval
@@ -1,3 +1,0 @@
-#!/usr/bin/env python
-from pyeval.main import main
-main()

--- a/pyeval/tests/test_autoimporter.py
+++ b/pyeval/tests/test_autoimporter.py
@@ -48,7 +48,7 @@ class AutoImporterTests (unittest.TestCase):
         self.assertIsNone(self.ai.path(self.ai.proxyImport('sys')))
 
     def test_pathDotSO(self):
-        self.assertRegexpMatches(self.ai.path(self.ai.proxyImport('_struct')), '\.so$')
+        self.assertRegexpMatches(self.ai.path(self.ai.proxyImport('bz2')), '\.so$')
 
     def test_nameTypeError(self):
         self.assertRaises(TypeError, self.ai.name, 42)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -41,7 +41,9 @@ STATUS=$?
 set -e
 
 echo -e '\n--- Generating Coverage Report ---'
-coverage html --include='pyeval/*'
+# This is a bit circular, thus brittle. We're using the test target pyeval:
+COVINC="$(pyeval 'sh(os.path.dirname(ai.path(pyeval)))')"
+coverage html --include="${COVINC}/*"
 
 echo 'Report generated.'
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import os, sys
+import sys
 from setuptools import setup, find_packages
 
 
@@ -16,7 +16,8 @@ setup(name='pyeval',
       author_email='nejucomo@gmail.com',
       license='GPLv3',
       url='https://bitbucket.org/nejucomo/pyeval',
-      scripts=[os.path.join('bin', 'pyeval')],
       packages=find_packages(),
       package_data={'pyeval': ['doc/*.txt']},
-      )
+      entry_points={'console_scripts': [
+          'pyeval = pyeval.main:main',
+      ]})


### PR DESCRIPTION
These changes are atop @coldfix cleanups to restore `run_tests.sh` to working order.

A good next step here would be to remove `run_tests.sh` entirely with a good thorough test framework. I wrote and prefer `onslaught` for this purpose but haven't searched for similar tools. `onslaught` does not yet support python3.